### PR TITLE
Add main package.json field

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lit-element",
     "lit"
   ],
+  "main": "wc-context.js",
   "files": [
     "context-provider.js",
     "context-consumer.js",


### PR DESCRIPTION
Default value of `main` field is `index.js`, but no such file is exported. This confuses some resolvers, causing them to throw errors on imports directly from `wc-context`. Adding correct main file to package fixes this issue

Note: This was not a problem on `v0.10`